### PR TITLE
Option to Ignore Hopper Inventories

### DIFF
--- a/ConvenientInventory/Compatibility/ApiHelper.cs
+++ b/ConvenientInventory/Compatibility/ApiHelper.cs
@@ -89,6 +89,14 @@ namespace ConvenientInventory.Compatibility
 
             api.AddBoolOption(
                 mod: modManifest,
+                getValue: () => config.IsIgnoreHoppers,
+                setValue: value => config.IsIgnoreHoppers = value,
+                name: () => helper.Translation.Get("ModConfigMenu.IsIgnoreHoppers.Name"),
+                tooltip: () => helper.Translation.Get("ModConfigMenu.IsIgnoreHoppers.Desc")
+            );
+
+            api.AddBoolOption(
+                mod: modManifest,
                 getValue: () => config.IsQuickStackIntoBuildingsWithInventories,
                 setValue: value => config.IsQuickStackIntoBuildingsWithInventories = value,
                 name: () => helper.Translation.Get("ModConfigMenu.IsQuickStackIntoBuildingsWithInventories.Name"),

--- a/ConvenientInventory/ConvenientInventory.csproj
+++ b/ConvenientInventory/ConvenientInventory.csproj
@@ -13,7 +13,7 @@
     <None Remove="assets\quickStackIcon.png" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="4.1.1" />
+    <PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="4.3.2" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="assets\autoOrganizeIcon.png" />

--- a/ConvenientInventory/ModConfig.cs
+++ b/ConvenientInventory/ModConfig.cs
@@ -10,6 +10,8 @@ namespace ConvenientInventory
 
         public string QuickStackRange { get; set; } = ConfigHelper.QuickStackRange_Default;
 
+        public bool IsIgnoreHoppers { get; set; } = true;
+
         public bool IsQuickStackIntoBuildingsWithInventories { get; set; } = true;
 
         public bool IsQuickStackIntoDressers { get; set; } = true;

--- a/ConvenientInventory/QuickStack/QuickStackLogic.cs
+++ b/ConvenientInventory/QuickStack/QuickStackLogic.cs
@@ -23,6 +23,11 @@ namespace ConvenientInventory.QuickStack
 
             List<TypedChest> chests = GetTypedChestsWithinRange(who, rangeStr, true);
 
+            if(ModEntry.Config.IsIgnoreHoppers)
+            {
+                chests = chests.Where(chest => chest.ChestType != ChestType.Hopper).ToList();
+            }
+
             Inventory playerInventory = who.Items;
 
             QuickStackAnimation quickStackAnimation = null;

--- a/ConvenientInventory/TypedChests/ChestType.cs
+++ b/ConvenientInventory/TypedChests/ChestType.cs
@@ -13,6 +13,7 @@
         JunimoHut,
         Special,
         Package,
-        Dresser
+        Dresser,
+        Hopper
     }
 }

--- a/ConvenientInventory/TypedChests/TypedChest.cs
+++ b/ConvenientInventory/TypedChests/TypedChest.cs
@@ -34,6 +34,11 @@ namespace ConvenientInventory.TypedChests
                 return chest.QualifiedItemId == "(BC)BigStoneChest" ? ChestType.BigStone : ChestType.BigNormal;
             }
 
+            if (chest.SpecialChestType == Chest.SpecialChestTypes.AutoLoader)
+            {
+                return ChestType.Hopper;
+            }
+
             if (chest.SpecialChestType != Chest.SpecialChestTypes.None)
             {
                 return ChestType.Special;

--- a/ConvenientInventory/i18n/default.json
+++ b/ConvenientInventory/i18n/default.json
@@ -25,6 +25,9 @@
   "ModConfigMenu.QuickStackControllerHotkey.Name": "Keybind (controller)",
   "ModConfigMenu.QuickStackControllerHotkey.Desc": "Press this button to quick stack your items.",
 
+  "ModConfigMenu.IsIgnoreHoppers.Name": "Ignore Hoppers?",
+  "ModConfigMenu.IsIgnoreHoppers.Desc": "Don't add items into hoppers.\nUsed for mods that add an inventory to hoppers like Filtered Chest Hoppers",
+
   "ModConfigMenu.IsQuickStackIntoBuildingsWithInventories.Name": "Quick stack into buildings?",
   "ModConfigMenu.IsQuickStackIntoBuildingsWithInventories.Desc": "If enabled, nearby buildings with inventories (such as Mills or Junimo Huts) will be considered when quick stacking.",
 


### PR DESCRIPTION
Added an option to filter out Hopper Inventories for Quick-stack Function for use with mods like Filtered Chest Hopper